### PR TITLE
Fixes 'DataError: value too long for type character varying(255)'

### DIFF
--- a/request/models.py
+++ b/request/models.py
@@ -48,7 +48,7 @@ class Request(models.Model):
     def from_http_request(self, request, response=None, commit=True):
         # Request infomation
         self.method = request.method
-        self.path = request.path
+        self.path = request.path[:255]
 
         self.is_secure = request.is_secure()
         self.is_ajax = request.is_ajax()


### PR DESCRIPTION
Hi kylef,

We're using django-request for our website and got this error for some requested paths that contain more than 255 chars:

>  django.db.backends.util in execute
>  DataError: value too long for type character varying(255)

I made a fix, so maybe you could merge this pull request? Thanks for the merge and for providing an easy way to gather statistics on the usage of our website.

Regards,
Erwin