### PR TITLE
Get IP address from request, even when proxied

### DIFF
--- a/request/middleware.py
+++ b/request/middleware.py
@@ -3,7 +3,7 @@ from django.core.urlresolvers import get_callable
 from request.models import Request
 from request import settings
 from request.router import patterns
-
+from request.utils import get_remote_addr
 
 class RequestMiddleware(object):
     def process_response(self, request, response):
@@ -20,7 +20,7 @@ class RequestMiddleware(object):
         if request.is_ajax() and settings.REQUEST_IGNORE_AJAX:
             return response
 
-        if request.META.get('REMOTE_ADDR') in settings.REQUEST_IGNORE_IP:
+        if get_remote_addr(request) in settings.REQUEST_IGNORE_IP:
             return response
 
         if getattr(request, 'user', False):

--- a/request/models.py
+++ b/request/models.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
 
 from request.managers import RequestManager
-from request.utils import HTTP_STATUS_CODES, browsers, engines
+from request.utils import HTTP_STATUS_CODES, browsers, engines, get_remote_addr
 from request import settings as request_settings
 
 
@@ -54,7 +54,7 @@ class Request(models.Model):
         self.is_ajax = request.is_ajax()
 
         # User infomation
-        self.ip = request.META.get('REMOTE_ADDR', '')
+        self.ip = get_remote_addr(request) or ''
         self.referer = request.META.get('HTTP_REFERER', '')[:255]
         self.user_agent = request.META.get('HTTP_USER_AGENT', '')[:255]
         self.language = request.META.get('HTTP_ACCEPT_LANGUAGE', '')[:255]

--- a/request/utils.py
+++ b/request/utils.py
@@ -66,6 +66,12 @@ HTTP_STATUS_CODES = (
     (510, _('Not Extended')),
 )
 
+REMOTE_ADDR_HEADER_KEYS = (
+    'HTTP_X_REAL_IP',
+    'HTTP_X_FORWARDED_FOR',
+    'REMOTE_ADDR'
+)
+
 from request.router import patterns
 
 browsers = patterns(('Unknown', {}),
@@ -124,3 +130,8 @@ engines = patterns(None,
     (r'^https?:\/\/([\.\w]+)?google.*(?:&|\?)q=(?P<keywords>[\+-_\w]+)', 'Google'),
     (r'^https?:\/\/([\.\w]+)?bing.*(?:&|\?)q=(?P<keywords>[\+-_\w]+)', 'Bing'),
 )
+
+def get_remote_addr(request):
+    for key in REMOTE_ADDR_HEADER_KEYS:
+        if key in request.META:
+            return request.META[key]


### PR DESCRIPTION
This resolves the issue of all anonymous requests coming from a local IP, using a util function called `get_remote_addr` to loop through a list of possible HTTP headers until it finds one that works. It's running in production on http://poddle.io/.