### PR TITLE
add setting to ignore requests based on user agent string

### DIFF
--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -68,6 +68,23 @@ Example:
         r'^admin/',
     )
 
+``REQUEST_IGNORE_USER_AGENTS``
+===========================
+
+Default: ``None``
+
+Any request with a user agent that matches any pattern in this list will be ignored.
+
+Example:
+
+.. code-block:: python
+
+    REQUEST_IGNORE_USER_AGENTS = (
+        r'^$', # ignore requests with no user agent string set
+        r'Googlebot',
+        r'Baiduspider',
+    )
+
 ``REQUEST_TRAFFIC_MODULES``
 =================================
 

--- a/request/middleware.py
+++ b/request/middleware.py
@@ -23,6 +23,10 @@ class RequestMiddleware(object):
         if request.META.get('REMOTE_ADDR') in settings.REQUEST_IGNORE_IP:
             return response
 
+        ignore = patterns(False, *settings.REQUEST_IGNORE_USER_AGENTS)
+        if ignore.resolve(request.META.get('HTTP_USER_AGENT', '')):
+            return response
+
         if getattr(request, 'user', False):
             if request.user.username in settings.REQUEST_IGNORE_USERNAME:
                 return response

--- a/request/settings.py
+++ b/request/settings.py
@@ -12,6 +12,7 @@ REQUEST_ANONYMOUS_IP = getattr(settings, 'REQUEST_ANONYMOUS_IP', False)
 REQUEST_LOG_USER = getattr(settings, 'REQUEST_LOG_USER', True)
 REQUEST_IGNORE_USERNAME = getattr(settings, 'REQUEST_IGNORE_USERNAME', tuple())
 REQUEST_IGNORE_PATHS = getattr(settings, 'REQUEST_IGNORE_PATHS', tuple())
+REQUEST_IGNORE_USER_AGENTS = getattr(settings, 'REQUEST_IGNORE_USER_AGENTS', tuple())
 
 REQUEST_TRAFFIC_MODULES = getattr(settings, 'REQUEST_TRAFFIC_MODULES', (
     'request.traffic.UniqueVisitor',


### PR DESCRIPTION
Users might want to exclude requests from web crawlers, or automated
tools with known user agent strings.  Add a setting for this.