### PR TITLE
update syntax to python >= 3.0

### DIFF
--- a/request/admin.py
+++ b/request/admin.py
@@ -87,7 +87,7 @@ class RequestAdmin(admin.ModelAdmin):
         else:
             days_step = 30
 
-        days = [date.today() - timedelta(day) for day in xrange(0, days_count, days_step)]
+        days = [date.today() - timedelta(day) for day in range(0, days_count, days_step)]
         days_qs = [(day, Request.objects.day(date=day)) for day in days]
         return HttpResponse(json.dumps(modules.graph(days_qs)), content_type='text/javascript')
 

--- a/request/plugins.py
+++ b/request/plugins.py
@@ -30,7 +30,7 @@ def set_count(items):
             item_count[item] = 0
         item_count[item] += 1
 
-    items = [(v, k) for k, v in item_count.iteritems()]
+    items = [(v, k) for k, v in item_count.items()]
     items.sort()
     items.reverse()
 


### PR DESCRIPTION
in python 3.0 for iterate dict we should use dict.items()
instead of dict.iteritems()