### PR TITLE
adding automatic generated migration file

### DIFF
--- a/request/migrations/0002_auto_20150710_0303.py
+++ b/request/migrations/0002_auto_20150710_0303.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('request', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='request',
+            name='ip',
+            field=models.GenericIPAddressField(verbose_name='ip address'),
+        ),
+        migrations.AlterField(
+            model_name='request',
+            name='method',
+            field=models.CharField(verbose_name='method', default='GET', max_length=7),
+        ),
+    ]


### PR DESCRIPTION
i had a problem when using the makemigrations django command, which failed at being able to write the appended migration file to the installed location in the system. this commit just adds what (my) django 1.8 makemigrations created when running with the appropriate permissions. i don't know whether or not this introduces any problems, it worked flawlessly on my installation setup, the error on makemigrations is gone and migrate applies cleanly. 