### PR TITLE
Fix #61: TypeError when unicode literals is used in REQUEST_IGNORE_PATHS

### DIFF
--- a/request/router.py
+++ b/request/router.py
@@ -18,7 +18,7 @@ class patterns(object):
         self.unknown = unknown
 
         for pattern in args:
-            if pattern.__class__ == str:
+            if pattern.__class__ in (str, u''.__class__):
                 self.patterns.append(RegexPattern(pattern))
             else:
                 self.patterns.append(RegexPattern(*pattern))

--- a/request/tests/test_settings.py
+++ b/request/tests/test_settings.py
@@ -1,0 +1,23 @@
+from __future__ import unicode_literals
+import unittest
+from request.router import patterns
+
+class PatternsTests(unittest.TestCase):
+    def test_unnamed_patterns(self):
+        self.assertEqual(patterns(False, r'^/admin/$').resolve('/admin/'),
+                         ('', {}))
+        self.assertEqual(patterns(False, r'^/admin/$').resolve('/login/'),
+                         False)
+
+    def test_named_patterns(self):
+        named = patterns(False, (r'^/admin/$', 'name'))
+        self.assertEqual(named.resolve('/admin/'),
+                         ('name', {}))
+        self.assertEqual(named.resolve('/login'),
+                         False)
+
+        named = patterns(False, [r'^/admin/$', 'name'])
+        self.assertEqual(named.resolve('/admin/'),
+                         ('name', {}))
+        self.assertEqual(named.resolve('/login'),
+                         False)


### PR DESCRIPTION
Handle Python 2 unicode strings in unnamed router patterns.

It is also possible to use `isinstance(pattern, six.text_type)` instead, but will add Six library dependency.