### PR TITLE
Added 100% tests coverage for request.management

### DIFF
--- a/request/management/commands/purgerequests.py
+++ b/request/management/commands/purgerequests.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand
-from django.utils import timezone
+from django.utils import timezone, six
 from request.models import Request
 
 DURATION_OPTIONS = {
@@ -12,6 +12,8 @@ DURATION_OPTIONS = {
     'months': lambda amount: timezone.now() - timedelta(days=(30 * amount)),  # 30-day month
     'years': lambda amount: timezone.now() - timedelta(weeks=(52 * amount)),  # 364-day year
 }
+
+input = raw_input if six.PY2 else input  # @ReservedAssignment
 
 
 class Command(BaseCommand):
@@ -53,7 +55,7 @@ class Command(BaseCommand):
             return
 
         if options.get('interactive'):
-            confirm = raw_input("""
+            confirm = input("""
 You have requested a database reset.
 This will IRREVERSIBLY DESTROY any
 requests created before %d %s ago.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,77 @@
+import mock
+from datetime import timedelta
+from django.test import TestCase
+from django.core.management import call_command
+from django.utils.timezone import now
+from request.management.commands.purgerequests import (DURATION_OPTIONS,
+                                                       Command as PurgeRequest)
+from request.models import Request
+
+
+class PurgeRequestsTest(TestCase):
+    def test_duration_options(self, *mock):
+        for opt, func in DURATION_OPTIONS.items():
+            self.assertLess(func(10), now())
+
+    @mock.patch('request.management.commands.purgerequests.input',
+                return_value='yes')
+    def test_purge_requests(self, *mock):
+        # setUp
+        Request.objects.create(ip='1.2.3.4')
+        request = Request.objects.create(ip='1.2.3.4')
+        request.time = now() - timedelta(days=31)
+        request.save()
+        # Test
+        PurgeRequest().handle(amount=1, duration='days')
+        self.assertEqual(1, Request.objects.count())
+
+    @mock.patch('request.management.commands.purgerequests.input',
+                return_value='yes')
+    def test_duration_without_s(self, *mock):
+        # setUp
+        Request.objects.create(ip='1.2.3.4')
+        request = Request.objects.create(ip='1.2.3.4')
+        request.time = now() - timedelta(days=31)
+        request.save()
+        # Test
+        PurgeRequest().handle(amount=1, duration='day')
+        self.assertEqual(1, Request.objects.count())
+
+    def test_invalid_duration(self, *mock):
+        # setUp
+        Request.objects.create(ip='1.2.3.4')
+        request = Request.objects.create(ip='1.2.3.4')
+        request.time = now() - timedelta(days=31)
+        request.save()
+        # Test
+        PurgeRequest().handle(amount=1, duration='foo')
+        self.assertEqual(2, Request.objects.count())
+
+    def test_no_request_to_delete(self, *mock):
+        PurgeRequest().handle(amount=1, duration='days')
+
+    @mock.patch('request.management.commands.purgerequests.input',
+                return_value='no')
+    def test_interactive_non_confirmed(self, *mock):
+        # setUp
+        Request.objects.create(ip='1.2.3.4')
+        request = Request.objects.create(ip='1.2.3.4')
+        request.time = now() - timedelta(days=31)
+        request.save()
+        # Test
+        PurgeRequest().handle(amount=1, duration='days', interactive=True)
+        self.assertTrue(mock[0].called)
+        self.assertEqual(2, Request.objects.count())
+
+    @mock.patch('request.management.commands.purgerequests.input',
+                return_value='yes')
+    def test_non_interactive(self, *mock):
+        # setUp
+        Request.objects.create(ip='1.2.3.4')
+        request = Request.objects.create(ip='1.2.3.4')
+        request.time = now() - timedelta(days=31)
+        request.save()
+        # Test
+        PurgeRequest().handle(amount=1, duration='days', interactive=False)
+        self.assertFalse(mock[0].called)
+        self.assertEqual(1, Request.objects.count())


### PR DESCRIPTION
I added a small trick for have raw_input in Python 3 and have it testable.