### PR TITLE
Change Google Chart URL (Fix #83)

### DIFF
--- a/request/templatetags/request_admin.py
+++ b/request/templatetags/request_admin.py
@@ -13,7 +13,7 @@ register.filter('trunc', trunc)
 
 #@register.simple_tag
 def pie_chart(items, width=440, height=190):
-    return 'http://chart.apis.google.com/chart?cht=p3&chd=t:%s&chs=%sx%s&chl=%s' % (
+    return '//chart.googleapis.com/chart?cht=p3&chd=t:%s&chs=%sx%s&chl=%s' % (
         ','.join([str(item[1]) for item in items]),
         width,
         height,

--- a/tests/test_templatestags.py
+++ b/tests/test_templatestags.py
@@ -21,11 +21,11 @@ class RequestAdminPieChart(TestCase):
     def test_pie_chart(self):
         inventory = ['apple', 'lemon', 'apple', 'orange', 'lemon', 'lemon']
         result = pie_chart(inventory)
-        self.assertTrue(result.startswith('http://chart.apis.google.com/chart?'))
+        self.assertTrue(result.startswith('//chart.googleapis.com/chart?'))
         self.assertIn('chs=440x190', result)
 
         result = pie_chart(inventory, width=100, height=100)
-        self.assertTrue(result.startswith('http://chart.apis.google.com/chart?'))
+        self.assertTrue(result.startswith('//chart.googleapis.com/chart?'))
         self.assertIn('chs=100x100', result)
 
 


### PR DESCRIPTION
Like suggested in issue #83:
I've remove the scheme from the URL and change the hostname for a secure one.

I tested and it works.